### PR TITLE
renamed OmnibusTrucker to avoid name collision

### DIFF
--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -1,4 +1,4 @@
-module OmnibusTrucker
+module OmnibusTruckerWindows
   class << self
     URL_MAP = {
       :p => :platform, :pv => :platform_version, :m => :machine,

--- a/recipes/downloader.rb
+++ b/recipes/downloader.rb
@@ -24,8 +24,8 @@ if(node[:omnibus_updater][:direct_url])
   remote_path = node[:omnibus_updater][:direct_url]
 else
   version = node[:omnibus_updater][:version] || ''
-  remote_path = OmnibusTrucker.url(
-    OmnibusTrucker.build_url(node,
+  remote_path = OmnibusTruckerWindows.url(
+    OmnibusTruckerWindows.build_url(node,
       :version => node[:omnibus_updater][:force_latest] ? nil : version.sub(/\-.+$/, ''),
       :prerelease => node[:omnibus_updater][:preview]
     ), node


### PR DESCRIPTION
I renamed OmnibusTrucker to OmnibusTruckerWindows to avoid a name collision with the omnibus_update cookbook.